### PR TITLE
feat: be less aggressive with undocumented headers

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -105,8 +105,8 @@ describe('HTTP Headers', () => {
   });
 
   describe('#getHeader', () => {
-    it('should throw a header if header is invalid', () => {
-      expect(() => getHeader('randomVal')).toThrow(new Error("'randomVal' is not a documented HTTP header."));
+    it('should return an empty object if header is invalid', () => {
+      expect(getHeader('randomVal')).toStrictEqual({});
     });
 
     it('should return HTTP header metadata if valid', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,5 @@ export const getHeaderMarkdown = (header: string): string => {
  */
 export default function getHeader(header: string): HTTPHeaderDescription {
   const normalizedHeader = normalizeHeader(header);
-
-  if (!isHeaderValid(normalizedHeader)) throw new Error(`'${header}' is not a documented HTTP header.`);
-
-  return HTTPHeaders[normalizedHeader];
+  return HTTPHeaders[normalizedHeader] ?? {};
 }


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

There's not a really good reason to throw errors for undocumented headers. There are many custom headers in the world (like Cloudflare's network-attached headers), and we shouldn't potentially break someone's system in those scenarios.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
